### PR TITLE
Update Kube ApiServer Service for backwards compatability

### DIFF
--- a/roles/controller_install/templates/kube-apiserver.service.j2
+++ b/roles/controller_install/templates/kube-apiserver.service.j2
@@ -21,6 +21,7 @@ ExecStart=/usr/local/bin/kube-apiserver \
   --etcd-servers={{ controller_etcd_cluster_urls }} \
   --event-ttl=1h \
   --encryption-provider-config={{ deployed_encryption_config_file }} \
+  --feature-gates=RemoveSelfLink=false \
   --kubelet-certificate-authority={{ deployed_ca_pem_file }} \
   --kubelet-client-certificate={{ deployed_k8s_pem_file }} \
   --kubelet-client-key={{ deployed_k8s_key_file }} \


### PR DESCRIPTION
Addresses concerns raised for our NFS Provisioner Lab seen here: https://github.com/alta3/labs/issues/400. 