### PR TITLE
447 updated setup script for kubeadm install

### DIFF
--- a/labs/setup/deploy-kubernetes-using-ansible/setup.sh
+++ b/labs/setup/deploy-kubernetes-using-ansible/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 echo STARTING ----------
-kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n"
+ssh controller "kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n""
 echo Maybe you are still in the process of setting up your cluster
 echo ignore any errors here. This is just making sure we remove kubeadm if it is installed.
 

--- a/labs/setup/etcd_backup/setup.sh
+++ b/labs/setup/etcd_backup/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
 
 echo STARTING ----------
-kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n"
+ssh controller "kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n""
 echo END OF SETUP ----------

--- a/labs/setup/kubeadm-install-lab/setup.sh
+++ b/labs/setup/kubeadm-install-lab/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
 
 echo STARTING ----------
-kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n"
+ssh controller "kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n""
 echo END OF SETUP ----------

--- a/labs/setup/kubeadm-join-node-lab/setup.sh
+++ b/labs/setup/kubeadm-join-node-lab/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
 
 echo STARTING ----------
-kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n"
+ssh controller "kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n""
 echo END OF SETUP ----------

--- a/labs/setup/kubeadm-network-plugins-lab/setup.sh
+++ b/labs/setup/kubeadm-network-plugins-lab/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
 
 echo STARTING ----------
-kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n"
+ssh controller "kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n""
 echo END OF SETUP ----------

--- a/labs/setup/kubeadm-prequisites-lab/setup.sh
+++ b/labs/setup/kubeadm-prequisites-lab/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
 
 echo STARTING ----------
-kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n"
+ssh controller "kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n""
 echo END OF SETUP ----------

--- a/labs/setup/kubeadmn_upgrade/setup.sh
+++ b/labs/setup/kubeadmn_upgrade/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
 
 echo STARTING ----------
-kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n"
+ssh controller "kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n""
 echo END OF SETUP ----------

--- a/labs/setup/purge_kubeadm/setup.sh
+++ b/labs/setup/purge_kubeadm/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
 
 echo STARTING ----------
-kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n"
+ssh controller "kubectl get nodes || printf "\n\n Looks like K8s may not be installed?\n\n""
 echo END OF SETUP ----------

--- a/labs/setup/setup
+++ b/labs/setup/setup
@@ -26,7 +26,7 @@ if [ ! -f "$LAB_ID/setup.sh" ]; then
     exit 1
 fi
 
-if [[ "${LAB_ID}" != kubeadm-prerequisites-lab && "${LAB_ID}" != kubeadm-network-plugins-lab && "${LAB_ID}" != kubeadm-install-lab && "${LAB_ID}" != kubeadm-join-node-lab && "${LAB_ID}" != etc_backup && "${LAB_ID}" != kubeadmn_upgrade && "${LAB_ID}" != purge_kubeadm && "${LAB_ID}" != cka-exam ]]; then
+if [[ "${LAB_ID}" != kubeadm-prerequisites-lab && "${LAB_ID}" != kubeadm-network-plugins-lab && "${LAB_ID}" != kubeadm-install-lab && "${LAB_ID}" != kubeadm-join-node-lab && "${LAB_ID}" != etc_backup && "${LAB_ID}" != kubeadmn_upgrade && "${LAB_ID}" != purge_kubeadm && "${LAB_ID}" != deploy-kubernetes-using-ansible && "${LAB_ID}" != cka-exam ]]; then
     # check if a k8sta3w cluster exists
     kubectl get nodes >> /dev/null
     if [ $? -ne 0 ]; then

--- a/labs/setup/setup
+++ b/labs/setup/setup
@@ -7,9 +7,9 @@ function now() {
 
 # cd into the setup directory
 SETUP_DIR=$(dirname "$(readlink -f "$0")")
-pushd "${SETUP_DIR}" >> /dev/null || exit 1 
+pushd "${SETUP_DIR}" >> /dev/null || exit 1
 
-if [ -z ${1+x} ]; then 
+if [ -z ${1+x} ]; then
     echo "[-] missing lab-name, to run:"
     printf "\tsetup lab-name\n"
     exit 1
@@ -26,14 +26,13 @@ if [ ! -f "$LAB_ID/setup.sh" ]; then
     exit 1
 fi
 
-if [ "${LAB_ID}" != cka-exam ]; then
-    # check if a cluster exists
+if [[ "${LAB_ID}" != kubeadm-prerequisites-lab && "${LAB_ID}" != kubeadm-network-plugins-lab && "${LAB_ID}" != kubeadm-install-lab && "${LAB_ID}" != kubeadm-join-node-lab && "${LAB_ID}" != etc_backup && "${LAB_ID}" != kubeadmn_upgrade && "${LAB_ID}" != purge_kubeadm && "${LAB_ID}" != cka-exam ]]; then
+    # check if a k8sta3w cluster exists
     kubectl get nodes >> /dev/null
     if [ $? -ne 0 ]; then
         echo "[-] No kubernetes cluster found"
         exit 1
     fi
-    
     # run all teardowns
     echo "[+] Cleaning cluster"
     TD_LOG_DIR=$(mktemp --directory --tmpdir "teardown.${LAB_ID}.XXXX")
@@ -47,6 +46,13 @@ if [ "${LAB_ID}" != cka-exam ]; then
         fi
     done
     wait
+else
+    # check if a kubeadm cluster exists
+    ssh controller "kubectl get nodes >> /dev/null"
+    if [ $? -ne 0 ]; then
+        echo "[-] No kubeadm cluster found"
+        exit 1
+    fi
 fi
 
 # run this setup
@@ -58,5 +64,5 @@ if [ $? -ne 0 ]; then
     echo "[-] Setup failed"
     exit 1
 fi
-popd >> /dev/null || exit 1 
+popd >> /dev/null || exit 1
 echo "[+] Setup complete"


### PR DESCRIPTION
See https://github.com/alta3/labs/issues/447#issuecomment-1489357164

Marked as critical because if we need these setups for each lab, the kubeadm labs are out until the setup is updated to include testing if a cluster exists on a controller (which is where the kubeadm installs it).