### PR TITLE
V1.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## From '1.29.4 to 1.31.1'
+
+# Kubernetes v1.31: Elli 
+
+<img src="https://kubernetes.io/images/blog/2024-08-13-kubernetes-1.31-release/k8s-1.31.png" width="400" height="400"/>
+
+- https://github.com/kubernetes/kubernetes/releases/tag/v1.31.4
+- https://kubernetes.io/blog/2024/08/13/kubernetes-v1-31-release/
+- https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-31
+
+## Supporting component releases
+
+```yaml
+k8s_version: "1.31.4"        # https://kubernetes.io/releases/#release-v1-31
+etcd_version: "3.5.17"       # https://github.com/etcd-io/etcd/releases
+cni_version: "1.6.2"         # https://github.com/containernetworking/plugins/releases 
+containerd_version: "1.7.24" # https://github.com/containerd/containerd/releases
+cri_tools_version: "1.31.1"  # https://github.com/kubernetes-sigs/cri-tools/releases
+cfssl_version: "1.6.5"       # https://github.com/cloudflare/cfssl/releases
+runc_version: "1.2.2"        # https://github.com/opencontainers/runc/releases
+coredns_version: "1.11.12"   # https://github.com/coredns/coredns/releases
+calico_version: "3.27.2"     # https://github.com/projectcalico/calico/releases
+helm_version: "3.16.3"       # https://github.com/helm/helm/releases
+gvisor_version: "latest"     # https://github.com/google/gvisor/releases
+```
+
 ## From `1.28.7` to `1.29.4`
 
 ##### Kubernetes v1.29: Mandala 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Components and versions:
 ```yaml
 k8s_version: "1.31.4"        # https://kubernetes.io/releases/#release-v1-31
 etcd_version: "3.5.17"       # https://github.com/etcd-io/etcd/releases
-cni_version: "1.6.1"         # https://github.com/containernetworking/plugins/releases 
+cni_version: "1.6.2"         # https://github.com/containernetworking/plugins/releases 
 containerd_version: "1.7.24" # https://github.com/containerd/containerd/releases
 cri_tools_version: "1.31.1"  # https://github.com/kubernetes-sigs/cri-tools/releases
 cfssl_version: "1.6.5"       # https://github.com/cloudflare/cfssl/releases

--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ Kubernetes The Alta3 Way guides you through bootstrapping a highly available Kub
 Components and versions:
 
 ```yaml
-k8s_version: "1.29.4"        # https://kubernetes.io/releases/#release-v1-28
-etcd_version: "3.5.12"       # https://github.com/etcd-io/etcd/releases
-cni_version: "1.4.1"         # https://github.com/containernetworking/plugins/releases 
-containerd_version: "1.7.16" # https://github.com/containerd/containerd/releases
-cri_tools_version: "1.30.0"  # https://github.com/kubernetes-sigs/cri-tools/releases
+k8s_version: "1.31.4"        # https://kubernetes.io/releases/#release-v1-31
+etcd_version: "3.5.17"       # https://github.com/etcd-io/etcd/releases
+cni_version: "1.6.1"         # https://github.com/containernetworking/plugins/releases 
+containerd_version: "1.7.24" # https://github.com/containerd/containerd/releases
+cri_tools_version: "1.31.1"  # https://github.com/kubernetes-sigs/cri-tools/releases
 cfssl_version: "1.6.5"       # https://github.com/cloudflare/cfssl/releases
-runc_version: "1.1.9"        # https://github.com/opencontainers/runc/releases
+runc_version: "1.2.2"        # https://github.com/opencontainers/runc/releases
 coredns_version: "1.11.12"   # https://github.com/coredns/coredns/releases
 calico_version: "3.27.2"     # https://github.com/projectcalico/calico/releases
-helm_version: "3.14.3"       # https://github.com/helm/helm/releases
+helm_version: "3.16.3"       # https://github.com/helm/helm/releases
 gvisor_version: "latest"     # https://github.com/google/gvisor/releases
 ```
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -39,7 +39,7 @@ helm:
 
 # controllers, nodes and localhost all need kubectl
 kubectl:
-  url: "https://storage.googleapis.com/kubernetes-release/release/v{{ k8s_version }}/bin/linux/amd64/kubectl"
+  url: "https://dl.k8s.io/release/v{{ k8s_version }}/bin/linux/amd64/kubectl"
   path: "/usr/local/bin/kubectl"
 
 # config and cert dirs
@@ -213,7 +213,7 @@ controller_api_localhost_url: "https://127.0.0.1:{{ controller_api_port }}"
 controller_services:
  - display_name: "Kubernetes API Server"
    name: "kube-apiserver"
-   url:  "https://storage.googleapis.com/kubernetes-release/release/v{{ k8s_version }}/bin/linux/amd64/kube-apiserver"
+   url:  "https://dl.k8s.io/release/v{{ k8s_version }}/bin/linux/amd64/kube-apiserver"
    path: "/usr/local/bin/kube-apiserver"
    mode: "0775"
    service_j2: "{{ role_path }}/templates/kube-apiserver.service.j2"
@@ -221,7 +221,7 @@ controller_services:
 
  - display_name: "Kubernetes Manager"
    name: "kube-controller-manager"
-   url: "https://storage.googleapis.com/kubernetes-release/release/v{{ k8s_version }}/bin/linux/amd64/kube-controller-manager"
+   url: "https://dl.k8s.io/release/v{{ k8s_version }}/bin/linux/amd64/kube-controller-manager"
    path: "/usr/local/bin/kube-controller-manager"
    mode: "0775"
    service_j2: "{{ role_path }}/templates/kube-controller-manager.service.j2"
@@ -229,7 +229,7 @@ controller_services:
 
  - display_name: "Kubernetes Scheduler"
    name: "kube-scheduler"
-   url: "https://storage.googleapis.com/kubernetes-release/release/v{{ k8s_version }}/bin/linux/amd64/kube-scheduler"
+   url: "https://dl.k8s.io/release/v{{ k8s_version }}/bin/linux/amd64/kube-scheduler"
    path: "/usr/local/bin/kube-scheduler"
    mode: "0775"
    service_j2: "{{ role_path }}/templates/kube-scheduler.service.j2"
@@ -277,12 +277,12 @@ kube_proxy_mode: "iptables"
 
 node_binaries:
  - name: "kubelet"
-   url: "https://storage.googleapis.com/kubernetes-release/release/v{{ k8s_version}}/bin/linux/amd64/kube-proxy"
+   url: "https://dl.k8s.io/release/v{{ k8s_version}}/bin/linux/amd64/kube-proxy"
    path: "/usr/local/bin/kube-proxy"
    mode: "0775"
 
  - name: "kube-proxy"
-   url: "https://storage.googleapis.com/kubernetes-release/release/v{{k8s_version}}/bin/linux/amd64/kubelet"
+   url: "https://dl.k8s.io/release/v{{k8s_version}}/bin/linux/amd64/kubelet"
    path: "/usr/local/bin/kubelet"
    mode: "0775"
 
@@ -302,7 +302,7 @@ node_binaries:
    mode: "0775"
 
  - name: "kubectl"
-   url: "https://storage.googleapis.com/kubernetes-release/release/v{{ k8s_version }}/bin/linux/amd64/kubectl"
+   url: "https://dl.k8s.io/release/v{{ k8s_version }}/bin/linux/amd64/kubectl"
    path: "/usr/local/bin/kubectl"
    mode: "0775"
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_python_interpreter: "/usr/bin/python3"
 # versions
 k8s_version: "1.31.4"        # https://kubernetes.io/releases/#release-v1-31
 etcd_version: "3.5.17"       # https://github.com/etcd-io/etcd/releases
-cni_version: "1.6.1"         # https://github.com/containernetworking/plugins/releases 
+cni_version: "1.6.2"         # https://github.com/containernetworking/plugins/releases 
 containerd_version: "1.7.24" # https://github.com/containerd/containerd/releases
 cri_tools_version: "1.31.1"  # https://github.com/kubernetes-sigs/cri-tools/releases
 cfssl_version: "1.6.5"       # https://github.com/cloudflare/cfssl/releases

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -2,16 +2,16 @@
 ansible_python_interpreter: "/usr/bin/python3"
 
 # versions
-k8s_version: "1.29.4"        # https://kubernetes.io/releases/#release-v1-28
-etcd_version: "3.5.12"       # https://github.com/etcd-io/etcd/releases
-cni_version: "1.4.1"         # https://github.com/containernetworking/plugins/releases 
-containerd_version: "1.7.16" # https://github.com/containerd/containerd/releases
-cri_tools_version: "1.30.0"  # https://github.com/kubernetes-sigs/cri-tools/releases
+k8s_version: "1.31.4"        # https://kubernetes.io/releases/#release-v1-31
+etcd_version: "3.5.17"       # https://github.com/etcd-io/etcd/releases
+cni_version: "1.6.1"         # https://github.com/containernetworking/plugins/releases 
+containerd_version: "1.7.24" # https://github.com/containerd/containerd/releases
+cri_tools_version: "1.31.1"  # https://github.com/kubernetes-sigs/cri-tools/releases
 cfssl_version: "1.6.5"       # https://github.com/cloudflare/cfssl/releases
-runc_version: "1.1.9"        # https://github.com/opencontainers/runc/releases
+runc_version: "1.2.2"        # https://github.com/opencontainers/runc/releases
 coredns_version: "1.11.12"   # https://github.com/coredns/coredns/releases
 calico_version: "3.27.2"     # https://github.com/projectcalico/calico/releases
-helm_version: "3.14.3"       # https://github.com/helm/helm/releases
+helm_version: "3.16.3"       # https://github.com/helm/helm/releases
 gvisor_version: "latest"     # https://github.com/google/gvisor/releases
 
 # cluster specifics


### PR DESCRIPTION
Updating to v1.31, including change log udpate and test log in issue. 

Also updated the website to pull the kubectl binary as they changed where it's hosted now. No longer in google api storage. 