### PR TITLE
Update my-ssh-secret.yaml character spacing

### DIFF
--- a/labs/yaml/ol-kustomization.yaml
+++ b/labs/yaml/ol-kustomization.yaml
@@ -1,13 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: prod-
-commonLabels:
-  variant: products
-bases:
+labels:
+  - pairs:
+      variant: products
+resources:
   - ../base
 patches:
-  - replicas.yaml
-  - nodeport.yaml
+  - path: replicas.yaml
+  - path: nodeport.yaml
 images:
   - name: nginx
     newTag: 1.19.6


### PR DESCRIPTION
lab 9.6

```
student@bchd:~$ vim my-ssh-secret.yaml
student@bchd:~$ kubectl apply -f my-ssh-secret.yaml
Error from server (BadRequest): error when creating "my-ssh-secret.yaml": Secret in version "v1" cannot be handled as a Secret: illegal base64 data at input byte 2531
```


-Lab 12.1
```
student@bchd:~/base$ kubectl apply -k ~/overlays/
error: invalid Kustomization: json: cannot unmarshal string into Go struct field Kustomization.patches of type types.Patch



vim ~/overlays/kustomization.yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namePrefix: prod-
commonLabels:
  variant: products
bases:
  - ../base
patches:
  - path: replicas.yaml     #### add path:
  - path: nodeport.yaml     #### add path:
images:
  - name: nginx
    newTag: 1.19.6


student@bchd:~$ kubectl apply -k ~/overlays/
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
service/prod-nginx-k-service created
deployment.apps/prod-nginx-k-deployment created

#### FIX ####

apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namePrefix: prod-
labels:
  - pairs:
      variant: products
resources:
  - ../base
patches:
  - path: replicas.yaml
  - path: nodeport.yaml
images:
  - name: nginx
    newTag: 1.19.6


```

Tested via seaneon-patch-1 and worked.