### PR TITLE
   fix(calico): grant kube-controllers service RBAC

### DIFF
--- a/roles/calico/templates/calico.yaml.j2
+++ b/roles/calico/templates/calico.yaml.j2
@@ -151,6 +151,16 @@ rules:
     verbs:
       - watch
       - list
+  # Service and services/status permissions are required by Calico kube-controllers.
+     - apiGroups: [""]
+       resources:
+         - services
+         - services/status
+       verbs:
+         - get
+         - list
+         - update
+         - watch
 ---
 # Source: calico/templates/calico-node-rbac.yaml
 # Include a clusterrole for the calico-node DaemonSet,


### PR DESCRIPTION
Calico kube-controllers v3.31 watches Kubernetes Services. Grant get/list/update/watch on services and services/status so the controller can start its service informer without RBAC errors.